### PR TITLE
Release v4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "zugkontrolle"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "assoc",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zugkontrolle"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["spamviech <spamviech@web.de>"]
 edition = "2021"
 license = "MIT"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 
 - Gleise-Canvas hört auf Touch-Eingaben. Es können mehrere Gleise gleichzeitig bewegt werden.
+- Modal-Widget unterstützt passthrough_events, die immer vom Underlay verarbeitet werden,
+  selbst wenn das Overlay aktuell angezeigt wird.
 
 ## 4.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,8 +2,7 @@
 
 ## Unreleased changes
 
-- Gleise-Canvas hört auf Touch-Eingaben. Es werden nur eingaben berücksichtigt,
-  die von der selben Quelle (Maus, bestimmter Finger) kommen, wie die aktuell verfolgte (z.B. gezogenes Gleis).
+- Gleise-Canvas hört auf Touch-Eingaben. Es können mehrere Gleise gleichzeitig bewegt werden.
 
 ## 4.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Gleise-Canvas hört auf Touch-Eingaben. Es werden nur eingaben berücksichtigt,
+  die von der selben Quelle (Maus, bestimmter Finger) kommen, wie die aktuell verfolgte (z.B. gezogenes Gleis).
+
 ## 4.0.0
 
 - neues Feature "raspi", ersetzt bisherige target-spezifische Logik

--- a/ide_settings_templates/.vscode/.cspell/custom-dictionary-workspace.txt
+++ b/ide_settings_templates/.vscode/.cspell/custom-dictionary-workspace.txt
@@ -3,6 +3,7 @@ AABB
 aarch
 abstand
 achse
+adler
 adresse
 adwaita
 ahash
@@ -13,13 +14,16 @@ Amanieu
 Andronik
 anfang
 anschlüsse
+ansi
 anzahl
 aparicio
 argumente
 armv
 arrayref
 arrayvec
+ascii
 Ashish
+Augusto
 ausgegraut
 auswahl
 autocfg
@@ -43,6 +47,7 @@ Burkert
 bytemuck
 byteorder
 calloop
+camino
 chacha
 Chibisov
 Chiovoloni
@@ -52,6 +57,8 @@ consts
 Contributers
 corasick
 Couprie
+cpus
+crichton
 crossfont
 Crozet
 d'Antras
@@ -84,7 +91,10 @@ erbauer
 erfolg
 ergebnis
 errno
+Esposito
+euclid
 Evgeniy
+exts
 Eyal
 Fackler
 faktor
@@ -152,6 +162,7 @@ Kaitchuck
 Kalderon
 kandidat
 kandidaten
+Kang
 Katharos
 Kazlauskas
 khronos
@@ -173,6 +184,7 @@ kurbo
 Kurdekar
 länge
 Lato
+lego
 leiter
 Levien
 libc
@@ -184,12 +196,15 @@ libxkbcommon
 lightdm
 linebreak
 linie
+linux
 lizenz
 lizenzen
 llln
 Loïc
 Lokathor
 Lukasz
+lyon
+Manish
 märklin
 Maryńczak
 Mathijs
@@ -203,6 +218,7 @@ methoden
 miniz
 mitte
 moduswechsel
+mozilla
 msvc
 musleabihf
 Naaman
@@ -251,6 +267,7 @@ raspberrypi
 rasperry
 raspi
 raspicam
+rasterizer
 Raux
 rechteck
 recv
@@ -283,6 +300,7 @@ scopeguard
 Scripta
 Scrollbares
 sctk
+Sébastien
 Šegan
 seite
 Sellier
@@ -291,6 +309,7 @@ serde
 serialisierbar
 Serialisierbar
 Sgeo
+simd
 siphasher
 skalarprodukt
 skalierfaktor
@@ -300,6 +319,7 @@ smallvec
 smithay
 softbuffer
 Soveu
+spamviech
 spirv
 sprache
 srgb
@@ -309,10 +329,13 @@ steuerungen
 strsim
 sublicensable
 Sverdrup
+syscall
 Tangren
 termcolor
 thema
 thiserror
+Thom
+Timmins
 tinyvec
 tlsv
 toleranz
@@ -324,6 +347,7 @@ Ulrik
 Unconfigured
 ungenauigkeit
 unicase
+unicode
 unterschiede
 validierung
 variante
@@ -344,6 +368,7 @@ vswhom
 vswwhom
 wahl
 wasi
+wayland
 wgpu
 widestring
 winapi
@@ -359,5 +384,6 @@ Yevhenii
 Yuki
 zeile
 zeilen
+zeno
 zentrum
 zerocopy

--- a/licenses/fetch_licenses.py
+++ b/licenses/fetch_licenses.py
@@ -7,7 +7,7 @@ import urllib.request
 import urllib.error
 
 script_name=os.path.splitext(os.path.basename(__file__))[0]
-licences_dir=os.path.dirname(os.path.abspath(__file__))
+licenses_dir=os.path.dirname(os.path.abspath(__file__))
 
 cargo_dir = os.path.join(os.path.expanduser("~"), ".cargo")
 # hash(probably) at the end might change, possibly with cargo update
@@ -58,7 +58,7 @@ def collect_cargo_lock_packages():
 
     packages = []
     current = Package()
-    with open(os.path.join(licences_dir, "..", "Cargo.lock"), 'r') as cargo_lock:
+    with open(os.path.join(licenses_dir, "..", "Cargo.lock"), 'r') as cargo_lock:
         found_package = False
         for line in cargo_lock:
             line = line.removesuffix("\n").removesuffix("\r").removesuffix("\n\r")
@@ -188,7 +188,7 @@ def copy_or_download_licenses(show_percent = 5):
     i = 0
     l = len(packages)
     step = int(show_percent * l / 100)
-    with open(os.path.join(os.path.join(licences_dir, f"{script_name}.log")), 'w') as log_file:
+    with open(os.path.join(os.path.join(licenses_dir, f"{script_name}.log")), 'w') as log_file:
         log(f"Fetch {l} licenses...", log_file)
         for package in packages:
             name_and_version = f"{package.name}-{package.version}"
@@ -200,11 +200,11 @@ def copy_or_download_licenses(show_percent = 5):
                         dir_path = os.path.join(git_dir, dir)
                         for rev in os.listdir(dir_path):
                             os.path.join(dir_path, rev)
-                            target_dir = os.path.join(licences_dir, name_and_version, rev)
+                            target_dir = os.path.join(licenses_dir, name_and_version, rev)
                             copy_licenses(src_dir, target_dir, log_file)
             else:
                 src_dir = os.path.join(crates_io_dir, name_and_version)
-                target_dir = os.path.join(licences_dir, name_and_version)
+                target_dir = os.path.join(licenses_dir, name_and_version)
                 copy_licenses(src_dir, target_dir, log_file)
             i += 1
             if i % step == 0:

--- a/python_scripts/deploy.py
+++ b/python_scripts/deploy.py
@@ -2,18 +2,22 @@
 
 import os.path
 
-from action import get_bin_path, send_to_raspi
-
+from action import get_bin_path, build, send_to_raspi, check_docker_podman
+from util import is_raspi_target
 import config
 
-# This assumes, prepare_release.py was executed before running this script
-# Hint: you can adjust the config.ini to only build the target binaries
+checked_docker_podman_running = False
 
 # only deploy activated targets
-for raspi_target in filter(lambda t: t in config.targets, [config.raspi32_target, config.raspi64_target]):
+for raspi_target in filter(is_raspi_target, config.targets):
     # build for raspi
     bin_path = get_bin_path(target=raspi_target)
-    # check if the file exists
-    assert(os.path.isfile(bin_path))
+    # re-build if the file doesn't exist
+    if not os.path.exists(bin_path):
+        # check if docker/podman is running
+        if not checked_docker_podman_running:
+            checked_docker_podman_running = check_docker_podman()
+        # build the zugkontrolle binary
+        build(target=raspi_target)
     # automatically transfer to raspi using scp
     send_to_raspi(bin_path, config.raspberry_user, config.raspberry_address)

--- a/python_scripts/deploy.py
+++ b/python_scripts/deploy.py
@@ -1,11 +1,13 @@
 #!/bin/python3
 
 import os.path
+import sys
 
 from action import get_bin_path, build, send_to_raspi, check_docker_podman
 from util import is_raspi_target
 import config
 
+rebuild = ("-r" in sys.argv) or ("--rebuild" in sys.argv)
 checked_docker_podman_running = False
 
 # only deploy activated targets
@@ -13,7 +15,7 @@ for raspi_target in filter(is_raspi_target, config.targets):
     # build for raspi
     bin_path = get_bin_path(target=raspi_target)
     # re-build if the file doesn't exist
-    if not os.path.exists(bin_path):
+    if rebuild or (not os.path.exists(bin_path)):
         # check if docker/podman is running
         if not checked_docker_podman_running:
             checked_docker_podman_running = check_docker_podman()

--- a/src/application.rs
+++ b/src/application.rs
@@ -264,8 +264,8 @@ where
         let mut command = Command::none();
 
         match message {
-            Nachricht::Gleis { definition_steuerung, klick_höhe } => {
-                self.gleis_hinzufügen(definition_steuerung, klick_höhe)
+            Nachricht::Gleis { definition_steuerung, klick_quelle, klick_höhe } => {
+                self.gleis_hinzufügen(definition_steuerung, klick_quelle, klick_höhe)
             },
             Nachricht::Modus(modus) => self.gleise.moduswechsel(modus),
             Nachricht::Bewegen(bewegen::Nachricht::StarteBewegung(bewegung)) => {

--- a/src/application/lizenzen/test.rs
+++ b/src/application/lizenzen/test.rs
@@ -280,7 +280,8 @@ fn passende_lizenzen() -> Result<(), (BTreeSet<(&'static str, &'static str)>, us
         }
     };
     for ((name, version), f) in lizenzen {
-        let ordner_pfad = format!("licenses/{name}-{version}");
+        let repo_pfad = env!("CARGO_MANIFEST_DIR");
+        let ordner_pfad = format!("{repo_pfad}/licenses/{name}-{version}");
         let standard_lizenz_pfad: &str = standard_lizenz_pfade
             .iter()
             .filter(|pfad| Path::new(&format!("{ordner_pfad}/{pfad}")).is_file())

--- a/src/application/modal.rs
+++ b/src/application/modal.rs
@@ -596,22 +596,23 @@ where
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, ElementNachricht>,
     ) -> event::Status {
-        if (self.passthrough_event)(&event) {
-            return event::Status::Ignored;
-        }
         let mut messages = Vec::new();
         let mut inner_shell = Shell::new(&mut messages);
         let mut status = if let Some(overlay) = &mut self.modal_overlay {
-            overlay.as_widget_mut().on_event(
-                self.state_overlay,
-                event,
-                layout,
-                cursor_position,
-                renderer,
-                clipboard,
-                &mut inner_shell,
-                &self.zustand.viewport,
-            )
+            if (self.passthrough_event)(&event) {
+                event::Status::Ignored
+            } else {
+                overlay.as_widget_mut().on_event(
+                    self.state_overlay,
+                    event,
+                    layout,
+                    cursor_position,
+                    renderer,
+                    clipboard,
+                    &mut inner_shell,
+                    &self.zustand.viewport,
+                )
+            }
         } else if let Some(overlay) = &mut self.element_overlay {
             overlay.on_event(event, layout, cursor_position, renderer, clipboard, &mut inner_shell)
         } else {

--- a/src/application/update.rs
+++ b/src/application/update.rs
@@ -65,7 +65,6 @@ impl<'t, L: LeiterAnzeige<'t, S, Renderer<Thema>>, S> Zugkontrolle<L, S> {
 
     /// Zeige einen neuen [AuswahlZustand], z.B. zum anpassen der Anschlüsse eines Gleises.
     pub fn zeige_auswahlzustand(&mut self, auswahl_zustand: AuswahlZustand<S>) {
-        self.gleise.gehalten_leeren();
         *self.auswahl_zustand.deref_mut() = Some(auswahl_zustand);
     }
 

--- a/src/application/update.rs
+++ b/src/application/update.rs
@@ -23,10 +23,13 @@ use crate::{
         auswahl::AuswahlZustand, bewegen::Bewegung, geschwindigkeit::LeiterAnzeige,
         style::thema::Thema, MessageBox, Nachricht, Zugkontrolle,
     },
-    gleis::gleise::{
-        self,
-        daten::{v2::BekannterZugtyp, SteuerungAktualisierenFehler},
-        id::{AnyDefinitionIdSteuerung, AnyId, AnyIdSteuerungSerialisiert},
+    gleis::{
+        gleise::{
+            self,
+            daten::{v2::BekannterZugtyp, SteuerungAktualisierenFehler},
+            id::{AnyDefinitionIdSteuerung, AnyId, AnyIdSteuerungSerialisiert},
+        },
+        knopf::KlickQuelle,
     },
     steuerung::{
         geschwindigkeit::{self, BekannterLeiter, GeschwindigkeitSerialisiert, Leiter},
@@ -277,6 +280,7 @@ where
     pub fn gleis_hinzufügen(
         &mut self,
         definition_steuerung: AnyDefinitionIdSteuerung,
+        klick_quelle: KlickQuelle,
         klick_höhe: Skalar,
     ) {
         let streckenabschnitt = self
@@ -285,8 +289,10 @@ where
             .map(|(streckenabschnitt_name, _farbe)| streckenabschnitt_name.clone());
         let streckenabschnitt2 =
             streckenabschnitt.map(|streckenabschnitt_name| streckenabschnitt_name.clone());
+        // FIXME x-position abhängig vom aktuellen pivot-punkt (rotation?)
         if let Err(fehler) = self.gleise.hinzufügen_gehalten_bei_maus(
             definition_steuerung,
+            klick_quelle,
             Vektor { x: Skalar(0.), y: klick_höhe },
             streckenabschnitt2,
             false,

--- a/src/application/update.rs
+++ b/src/application/update.rs
@@ -65,6 +65,7 @@ impl<'t, L: LeiterAnzeige<'t, S, Renderer<Thema>>, S> Zugkontrolle<L, S> {
 
     /// Zeige einen neuen [AuswahlZustand], z.B. zum anpassen der Anschlüsse eines Gleises.
     pub fn zeige_auswahlzustand(&mut self, auswahl_zustand: AuswahlZustand<S>) {
+        self.gleise.gehalten_leeren();
         *self.auswahl_zustand.deref_mut() = Some(auswahl_zustand);
     }
 

--- a/src/application/view.rs
+++ b/src/application/view.rs
@@ -3,11 +3,12 @@
 use std::fmt::Debug;
 
 use iced::{
+    mouse, touch,
     widget::{
         scrollable::{self, Scrollable},
         Button, Canvas, Column, Container, Row, Rule, Slider, Space, Text,
     },
-    Alignment, Element, Length, Renderer,
+    Alignment, Element, Event, Length, Renderer,
 };
 use itertools::Itertools;
 
@@ -32,7 +33,7 @@ use crate::{
             steuerung::MitSteuerung,
             Gleise, Modus,
         },
-        knopf::Knopf,
+        knopf::{KlickQuelle, Knopf},
         kreuzung::Kreuzung,
         kurve::Kurve,
         weiche::{
@@ -127,8 +128,23 @@ where
             AuswahlZustand::view(modal, gleise, &lager.pcf8574, *scrollable_style, *i2c_settings)
                 .map(modal::Nachricht::äußeres_modal)
         };
+        let passthrough_event = |event: &Event| {
+            let klick_quelle = match event {
+                Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                    KlickQuelle::Maus
+                },
+                Event::Touch(
+                    touch::Event::FingerLifted { id, position: _ }
+                    | touch::Event::FingerLost { id, position: _ },
+                ) => KlickQuelle::Touch(*id),
+                _ => return false,
+            };
+            gleise.hat_gehaltenes_gleis(klick_quelle)
+        };
         let auswahlzustand = Element::from(
-            Modal::neu(column, auswahl_zustand, zeige_auswahlzustand).schließe_bei_esc(),
+            Modal::neu(column, auswahl_zustand, zeige_auswahlzustand)
+                .passthrough_event(passthrough_event)
+                .schließe_bei_esc(),
         );
 
         let zeige_message_box = |message_box: &MessageBox| {
@@ -147,8 +163,9 @@ where
             )
             .map(modal::Nachricht::underlay_from::<NachrichtClone<L>>)
         };
-        let message_box_modal =
-            Modal::neu(auswahlzustand, message_box, zeige_message_box).schließe_bei_esc();
+        let message_box_modal = Modal::neu(auswahlzustand, message_box, zeige_message_box)
+            .passthrough_event(passthrough_event)
+            .schließe_bei_esc();
         message_box_modal.into()
     }
 }

--- a/src/application/view.rs
+++ b/src/application/view.rs
@@ -139,7 +139,9 @@ where
                 ) => KlickQuelle::Touch(*id),
                 _ => return false,
             };
-            gleise.hat_gehaltenes_gleis(klick_quelle)
+            let gehalten = gleise.hat_gehaltenes_gleis(klick_quelle);
+            log::debug!("{event:?} -> {gehalten}");
+            gehalten
         };
         let auswahlzustand = Element::from(
             Modal::neu(column, auswahl_zustand, zeige_auswahlzustand)

--- a/src/gleis/gleise.rs
+++ b/src/gleis/gleise.rs
@@ -21,7 +21,7 @@ use crate::{
             de_serialisieren::ZugtypDeserialisierenFehler, GeschwindigkeitEntferntFehler,
             StreckenabschnittEntferntFehler, Zustand,
         },
-        nachricht::{Gehalten, Nachricht},
+        nachricht::{Gehalten, KlickQuelle, Nachricht},
     },
     steuerung::{
         geschwindigkeit::{self, Geschwindigkeit, Leiter},
@@ -51,7 +51,7 @@ pub mod update;
 #[derive(Debug)]
 enum ModusDaten {
     /// Im Bauen-Modus können Gleise hinzugefügt, bewegt, angepasst und bewegt werden.
-    Bauen { gehalten: Option<Gehalten>, letzter_klick: Instant },
+    Bauen { gehalten: Option<Gehalten>, letzter_klick: Option<(KlickQuelle, Instant)> },
     /// Im Fahren-Modus werden die mit den Gleisen assoziierten Aktionen durchgeführt.
     Fahren,
 }
@@ -59,7 +59,7 @@ enum ModusDaten {
 impl ModusDaten {
     fn neu(modus: Modus) -> Self {
         match modus {
-            Modus::Bauen => ModusDaten::Bauen { gehalten: None, letzter_klick: Instant::now() },
+            Modus::Bauen => ModusDaten::Bauen { gehalten: None, letzter_klick: None },
             Modus::Fahren => ModusDaten::Fahren,
         }
     }
@@ -328,7 +328,6 @@ where
 {
     type State = ();
 
-    #[inline(always)]
     fn draw(
         &self,
         state: &Self::State,
@@ -340,7 +339,6 @@ where
         Gleise::draw(self, state, renderer, thema, bounds, cursor)
     }
 
-    #[inline(always)]
     fn update(
         &self,
         state: &mut Self::State,

--- a/src/gleis/gleise.rs
+++ b/src/gleis/gleise.rs
@@ -133,6 +133,14 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
         self.modus = ModusDaten::neu(modus);
     }
 
+    /// Gibt es ein zur [KlickQuelle] gehörendes gehaltenes Gleis.
+    pub fn hat_gehaltenes_gleis(&self, klick_quelle: KlickQuelle) -> bool {
+        match &self.modus {
+            ModusDaten::Bauen { gehalten, .. } => gehalten.contains_key(&klick_quelle),
+            ModusDaten::Fahren => false,
+        }
+    }
+
     /// Aktuelle Pivot-Punkt und Dreh-Winkel
     pub fn pivot(&self) -> &Position {
         &self.pivot

--- a/src/gleis/gleise/draw.rs
+++ b/src/gleis/gleise/draw.rs
@@ -1,5 +1,7 @@
 //! [draw](iced::widget::canvas::Program::draw)-Methode für [Gleise].
 
+use std::collections::HashSet;
+
 use iced::{
     mouse::Cursor,
     widget::canvas::{Geometry, Program},
@@ -57,21 +59,24 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
             &self.skalieren,
             |frame| {
                 // Zeichne Gleise
-                let gehalten_id: Option<AnyId>;
+                let gehalten_ids: HashSet<AnyId>;
                 let modus_bauen: bool;
                 match modus {
                     ModusDaten::Bauen { gehalten, .. } => {
-                        gehalten_id = gehalten
-                            .as_ref()
-                            .map(|Gehalten { gleis_steuerung, .. }| gleis_steuerung.id());
+                        gehalten_ids = gehalten
+                            .iter()
+                            .map(|(_klick_quelle, Gehalten { gleis_steuerung, .. })| {
+                                gleis_steuerung.id()
+                            })
+                            .collect();
                         modus_bauen = true;
                     },
                     ModusDaten::Fahren => {
-                        gehalten_id = None;
+                        gehalten_ids = HashSet::new();
                         modus_bauen = false;
                     },
                 };
-                let ist_gehalten = |id| Some(id) == gehalten_id;
+                let ist_gehalten = |id| gehalten_ids.contains(&id);
                 let transparent_hintergrund = |id, fließend| {
                     Transparenz::true_reduziert(if modus_bauen {
                         ist_gehalten(id)

--- a/src/gleis/gleise/hinzufügen_entfernen.rs
+++ b/src/gleis/gleise/hinzufügen_entfernen.rs
@@ -1,6 +1,6 @@
 //! Methoden zum hinzufügen, verschieben und entfernen von Gleisen.
 
-use log::error;
+use log::{error, info};
 
 use crate::{
     anschluss::Lager,
@@ -83,13 +83,14 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
                 ) => AnyIdSteuerung::Kreuzung(id.clone(), steuerung),
                 wert => unreachable!("Inkompatible GleisId und Steuerung: {wert:?}"),
             };
-            let quelle_str = format!("{klick_quelle:?}");
             let bisher = gehalten.insert(
                 klick_quelle,
                 Gehalten { gleis_steuerung, halte_position, winkel, bewegt: true },
             );
             if let Some(bisher) = bisher {
-                error!("Gehaltenes Gleis für {quelle_str} ersetzt: {bisher:?}");
+                error!("Gehaltenes Gleis für {klick_quelle:?} ersetzt: {bisher:?}");
+            } else {
+                info!("Neues gehaltenes Gleis für {klick_quelle:?}.");
             }
         }
         Ok(gleis_id)

--- a/src/gleis/gleise/hinzufügen_entfernen.rs
+++ b/src/gleis/gleise/hinzufügen_entfernen.rs
@@ -124,15 +124,6 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
         Ok(())
     }
 
-    /// Leere die aktuell gehaltenen Gleise.
-    /// Danach müssen Gleise neu zum z.B. bewegen ausgewählt/angeklickt werden.
-    pub fn gehalten_leeren(&mut self) {
-        if let ModusDaten::Bauen { gehalten, .. } = &mut self.modus {
-            info!("Leere aktuell gehaltene Gleise.");
-            gehalten.clear();
-        }
-    }
-
     /// Setzte (oder entferne) den [Streckenabschnitt](streckenabschnitt::Streckenabschnitt)
     /// für das [Gleis] assoziiert mit der [GleisId].
     ///

--- a/src/gleis/gleise/hinzufügen_entfernen.rs
+++ b/src/gleis/gleise/hinzufügen_entfernen.rs
@@ -124,6 +124,15 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
         Ok(())
     }
 
+    /// Leere die aktuell gehaltenen Gleise.
+    /// Danach müssen Gleise neu zum z.B. bewegen ausgewählt/angeklickt werden.
+    pub fn gehalten_leeren(&mut self) {
+        if let ModusDaten::Bauen { gehalten, .. } = &mut self.modus {
+            info!("Leere aktuell gehaltene Gleise.");
+            gehalten.clear();
+        }
+    }
+
     /// Setzte (oder entferne) den [Streckenabschnitt](streckenabschnitt::Streckenabschnitt)
     /// für das [Gleis] assoziiert mit der [GleisId].
     ///

--- a/src/gleis/gleise/nachricht.rs
+++ b/src/gleis/gleise/nachricht.rs
@@ -52,7 +52,7 @@ pub(in crate::gleis::gleise) enum ZustandAktualisierenEnum {
     LetzterKlick(KlickQuelle, Instant),
     /// Aktualisiere die letzte bekannte Canvas-Größe.
     LetzteCanvasGröße(Vektor),
-    /// Aktualisiere das aktuell gehaltene Gleis.
+    /// Aktualisiere das aktuell von der [KlickQuelle] gehaltene Gleis.
     GehaltenAktualisieren(KlickQuelle, Option<Gehalten>),
     /// Bewege ein Gleis an die neue Position.
     GehaltenBewegen(KlickQuelle, Vektor),

--- a/src/gleis/gleise/nachricht.rs
+++ b/src/gleis/gleise/nachricht.rs
@@ -2,10 +2,11 @@
 
 use std::time::Instant;
 
-use iced_core::touch::Finger;
-
 use crate::{
-    gleis::gleise::id::{AnyId, AnyIdSteuerung, AnyIdSteuerungSerialisiert},
+    gleis::{
+        gleise::id::{AnyId, AnyIdSteuerung, AnyIdSteuerungSerialisiert},
+        knopf::KlickQuelle,
+    },
     steuerung::plan::{AktionStreckenabschnitt, AnyAktionSchalten},
     typen::{vektor::Vektor, winkel::Winkel},
 };
@@ -16,12 +17,6 @@ pub(in crate::gleis::gleise) struct Gehalten {
     pub(in crate::gleis::gleise) halte_position: Vektor,
     pub(in crate::gleis::gleise) winkel: Winkel,
     pub(in crate::gleis::gleise) bewegt: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::gleis::gleise) enum KlickQuelle {
-    Maus,
-    Touch(Finger),
 }
 
 /// Eine GUI-Nachricht als Reaktion auf Interaktion mit dem [Canvas](iced::widget::canvas::Canvas).
@@ -58,9 +53,9 @@ pub(in crate::gleis::gleise) enum ZustandAktualisierenEnum {
     /// Aktualisiere die letzte bekannte Canvas-Größe.
     LetzteCanvasGröße(Vektor),
     /// Aktualisiere das aktuell gehaltene Gleis.
-    GehaltenAktualisieren(Option<Gehalten>),
+    GehaltenAktualisieren(KlickQuelle, Option<Gehalten>),
     /// Bewege ein Gleis an die neue Position.
-    GehaltenBewegen(Vektor),
+    GehaltenBewegen(KlickQuelle, Vektor),
     /// Entferne ein Gleis.
     GleisEntfernen(AnyId),
 }

--- a/src/gleis/gleise/nachricht.rs
+++ b/src/gleis/gleise/nachricht.rs
@@ -2,6 +2,8 @@
 
 use std::time::Instant;
 
+use iced_core::touch::Finger;
+
 use crate::{
     gleis::gleise::id::{AnyId, AnyIdSteuerung, AnyIdSteuerungSerialisiert},
     steuerung::plan::{AktionStreckenabschnitt, AnyAktionSchalten},
@@ -14,6 +16,12 @@ pub(in crate::gleis::gleise) struct Gehalten {
     pub(in crate::gleis::gleise) halte_position: Vektor,
     pub(in crate::gleis::gleise) winkel: Winkel,
     pub(in crate::gleis::gleise) bewegt: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::gleis::gleise) enum KlickQuelle {
+    Maus,
+    Touch(Finger),
 }
 
 /// Eine GUI-Nachricht als Reaktion auf Interaktion mit dem [Canvas](iced::widget::canvas::Canvas).
@@ -45,8 +53,8 @@ pub struct ZustandAktualisieren(pub(in crate::gleis::gleise) ZustandAktualisiere
 pub(in crate::gleis::gleise) enum ZustandAktualisierenEnum {
     /// Aktualisiere die letzte bekannte Maus-Position.
     LetzteMausPosition(Vektor),
-    /// Aktualisiere die Zeit des letzten Maus-Klicks.
-    LetzterKlick(Instant),
+    /// Aktualisiere die Zeit und Art des letzten Maus- oder Touch-Klicks.
+    LetzterKlick(KlickQuelle, Instant),
     /// Aktualisiere die letzte bekannte Canvas-Größe.
     LetzteCanvasGröße(Vektor),
     /// Aktualisiere das aktuell gehaltene Gleis.

--- a/src/gleis/gleise/update.rs
+++ b/src/gleis/gleise/update.rs
@@ -64,11 +64,15 @@ fn aktion_bauen(
     halte_position: Vektor,
     winkel: Winkel,
 ) {
-    // FIXME quelle-Check auf Maus/Finger (ohne ID) beschränken
     let diff = letzter_klick
         .as_ref()
         .and_then(|(letzte_quelle, letzte_zeit)| {
-            if *letzte_quelle == quelle {
+            let selbe_klick_art = match (letzte_quelle, quelle) {
+                (KlickQuelle::Maus, KlickQuelle::Maus) => true,
+                (KlickQuelle::Touch(_), KlickQuelle::Touch(_)) => true,
+                _ => false,
+            };
+            if selbe_klick_art {
                 now.checked_duration_since(*letzte_zeit)
             } else {
                 None

--- a/src/gleis/gleise/update.rs
+++ b/src/gleis/gleise/update.rs
@@ -52,7 +52,7 @@ fn berechne_canvas_position(
     })
 }
 
-const DOUBLE_CLICK_TIME: Duration = Duration::from_millis(500);
+const DOUBLE_CLICK_TIME: Duration = Duration::from_millis(200);
 
 /// Aktion für ein im Modus "Bauen" angeklicktes Gleis.
 fn aktion_bauen(

--- a/src/gleis/gleise/update.rs
+++ b/src/gleis/gleise/update.rs
@@ -280,31 +280,23 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
                 (Cursor::Available(position), KlickQuelle::Touch(finger))
             },
         };
-        if let ModusDaten::Bauen {
-            gehalten,
-            letzter_klick: Some((letzte_quelle, _zeitpunkt)),
-            ..
-        } = &self.modus
-        {
+        if let ModusDaten::Bauen { gehalten, .. } = &self.modus {
             if let Some(Gehalten { gleis_steuerung, bewegt, .. }) = gehalten.get(&quelle) {
-                // FIXME warum wird nur die letzte_quelle berücksichtigt?
-                if *letzte_quelle == quelle {
-                    let gleis_id = gleis_steuerung.id();
-                    if *bewegt {
-                        if !cursor.is_over(bounds) {
-                            messages.push(Nachricht::from(
-                                ZustandAktualisierenEnum::GleisEntfernen(gleis_id),
-                            ));
-                        }
-                    } else {
-                        // setze Streckenabschnitt, falls Maus (von ButtonPressed) nicht bewegt
-                        messages.push(Nachricht::SetzeStreckenabschnitt(gleis_id));
+                let gleis_id = gleis_steuerung.id();
+                if *bewegt {
+                    if !cursor.is_over(bounds) {
+                        messages.push(Nachricht::from(ZustandAktualisierenEnum::GleisEntfernen(
+                            gleis_id,
+                        )));
                     }
-                    messages.push(Nachricht::from(
-                        ZustandAktualisierenEnum::GehaltenAktualisieren(quelle, None),
-                    ));
-                    *event_status = event::Status::Captured;
+                } else {
+                    // setze Streckenabschnitt, falls Maus (von ButtonPressed) nicht bewegt
+                    messages.push(Nachricht::SetzeStreckenabschnitt(gleis_id));
                 }
+                messages.push(Nachricht::from(ZustandAktualisierenEnum::GehaltenAktualisieren(
+                    quelle, None,
+                )));
+                *event_status = event::Status::Captured;
             }
         }
     }
@@ -328,14 +320,8 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
         ) {
             messages
                 .push(Nachricht::from(ZustandAktualisierenEnum::LetzteMausPosition(canvas_pos)));
-            if let ModusDaten::Bauen {
-                gehalten,
-                letzter_klick: Some((letzte_quelle, _zeitpunkt)),
-                ..
-            } = &self.modus
-            {
-                // FIXME warum wird nur die letzte_quelle berücksichtigt?
-                if gehalten.contains_key(&quelle) && (*letzte_quelle == quelle) {
+            if let ModusDaten::Bauen { gehalten, .. } = &self.modus {
+                if gehalten.contains_key(&quelle) {
                     messages.push(Nachricht::from(ZustandAktualisierenEnum::GehaltenBewegen(
                         quelle, canvas_pos,
                     )));

--- a/src/gleis/gleise/update.rs
+++ b/src/gleis/gleise/update.rs
@@ -5,10 +5,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+use either::Either;
 use iced::{
     mouse::{self, Cursor},
+    touch::{self, Finger},
     widget::canvas::{event, Event, Program},
-    Rectangle, Renderer,
+    Point, Rectangle, Renderer,
 };
 use log::error;
 use nonempty::{nonempty, NonEmpty};
@@ -22,7 +24,7 @@ use crate::{
             id::AnyIdSteuerung,
             nachricht::{Gehalten, Nachricht, ZustandAktualisieren, ZustandAktualisierenEnum},
             steuerung::Steuerung,
-            Gleise, ModusDaten,
+            Gleise, KlickQuelle, ModusDaten,
         },
         weiche,
     },
@@ -57,11 +59,14 @@ fn aktion_bauen(
     nachrichten: &mut Vec<Nachricht>,
     gleis_steuerung: AnyIdSteuerung,
     now: Instant,
-    letzter_klick: Instant,
+    letzter_klick: &Option<(KlickQuelle, Instant)>,
     halte_position: Vektor,
     winkel: Winkel,
 ) {
-    let diff = now.checked_duration_since(letzter_klick).unwrap_or(Duration::MAX);
+    let diff = letzter_klick
+        .as_ref()
+        .and_then(|(_quelle, letzte_zeit)| now.checked_duration_since(*letzte_zeit))
+        .unwrap_or(Duration::MAX);
     let gleis_steuerung_serialisiert = gleis_steuerung.serialisiere();
     if diff < DOUBLE_CLICK_TIME {
         nachrichten.push(Nachricht::AnschlüsseAnpassen(gleis_steuerung_serialisiert));
@@ -160,13 +165,13 @@ where
     }
 }
 
-fn aktion_gleis_an_position<'t, L, AktualisierenNachricht>(
+fn aktion_gleis_an_position<L, AktualisierenNachricht>(
     bounds: Rectangle,
-    cursor: &'t Cursor,
-    modus: &'t ModusDaten,
-    zustand2: &Zustand<L>,
-    pivot: &'t Position,
-    skalieren: &'t Skalar,
+    cursor_or_finger: Either<Cursor, (Finger, Point)>,
+    modus: &ModusDaten,
+    zustand: &Zustand<L>,
+    pivot: &Position,
+    skalieren: &Skalar,
     sender: &Sender<AktualisierenNachricht>,
 ) -> (event::Status, Vec<Nachricht>)
 where
@@ -175,22 +180,31 @@ where
 {
     let mut nachrichten = Vec::new();
     let mut status = event::Status::Ignored;
+    let (cursor, aktueller_klick) = match cursor_or_finger {
+        Either::Left(cursor) => (cursor, KlickQuelle::Maus),
+        Either::Right((finger, position)) => {
+            (Cursor::Available(position), KlickQuelle::Touch(finger))
+        },
+    };
     if cursor.is_over(bounds) {
         if let Some(canvas_pos) = berechne_canvas_position(&bounds, &cursor, pivot, skalieren) {
-            let gleis_an_position2 = zustand2.gleis_an_position(canvas_pos);
+            let gleis_an_position = zustand.gleis_an_position(canvas_pos);
             match modus {
-                ModusDaten::Bauen { gehalten: gehalten2, letzter_klick } => {
+                ModusDaten::Bauen { gehalten, letzter_klick } => {
                     let now = Instant::now();
-                    nachrichten.push(Nachricht::from(ZustandAktualisierenEnum::LetzterKlick(now)));
-                    if gehalten2.is_none() {
+                    nachrichten.push(Nachricht::from(ZustandAktualisierenEnum::LetzterKlick(
+                        aktueller_klick,
+                        now,
+                    )));
+                    if gehalten.is_none() {
                         if let Some((gleis_steuerung, halte_position, winkel, _streckenabschnitt)) =
-                            gleis_an_position2
+                            gleis_an_position
                         {
                             aktion_bauen(
                                 &mut nachrichten,
                                 gleis_steuerung,
                                 now,
-                                *letzter_klick,
+                                letzter_klick,
                                 halte_position,
                                 winkel,
                             );
@@ -200,7 +214,7 @@ where
                 },
                 ModusDaten::Fahren => {
                     if let Some((id_steuerung, _halte_position, _winkel, streckenabschnitt)) =
-                        gleis_an_position2
+                        gleis_an_position
                     {
                         let nachricht = aktion_fahren(
                             id_steuerung,
@@ -223,6 +237,102 @@ where
 }
 
 impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
+    fn maus_oder_touch_pressed(
+        &self,
+        cursor_oder_finger: Either<Cursor, (Finger, Point)>,
+        bounds: Rectangle,
+        event_status: &mut event::Status,
+        messages: &mut NonEmpty<Nachricht>,
+    ) where
+        AktualisierenNachricht: 'static + From<gleise::steuerung::Aktualisieren> + Send,
+    {
+        let Gleise { zustand, pivot, skalieren, modus, sender, .. } = self;
+        let (status, nachrichten) = aktion_gleis_an_position(
+            bounds,
+            cursor_oder_finger,
+            modus,
+            zustand,
+            pivot,
+            skalieren,
+            &sender,
+        );
+        *event_status = status;
+        messages.extend(nachrichten);
+    }
+
+    fn maus_oder_touch_released(
+        &self,
+        cursor_oder_finger: Either<Cursor, (Finger, Point)>,
+        bounds: Rectangle,
+        event_status: &mut event::Status,
+        messages: &mut NonEmpty<Nachricht>,
+    ) {
+        let (cursor, quelle) = match cursor_oder_finger {
+            Either::Left(cursor) => (cursor, KlickQuelle::Maus),
+            Either::Right((finger, position)) => {
+                (Cursor::Available(position), KlickQuelle::Touch(finger))
+            },
+        };
+        if let ModusDaten::Bauen {
+            gehalten: Some(Gehalten { gleis_steuerung, bewegt, .. }),
+            letzter_klick: Some((letzte_quelle, _zeitpunkt)),
+            ..
+        } = &self.modus
+        {
+            if *letzte_quelle == quelle {
+                let gleis_id = gleis_steuerung.id();
+                if *bewegt {
+                    if !cursor.is_over(bounds) {
+                        messages.push(Nachricht::from(ZustandAktualisierenEnum::GleisEntfernen(
+                            gleis_id,
+                        )));
+                    }
+                } else {
+                    // setze Streckenabschnitt, falls Maus (von ButtonPressed) nicht bewegt
+                    messages.push(Nachricht::SetzeStreckenabschnitt(gleis_id));
+                }
+                messages
+                    .push(Nachricht::from(ZustandAktualisierenEnum::GehaltenAktualisieren(None)));
+                *event_status = event::Status::Captured;
+            }
+        }
+    }
+
+    fn maus_oder_touch_moved(
+        &self,
+        cursor_oder_finger: Either<Point, (Finger, Point)>,
+        bounds: Rectangle,
+        event_status: &mut event::Status,
+        messages: &mut NonEmpty<Nachricht>,
+    ) {
+        let (position, quelle) = match cursor_oder_finger {
+            Either::Left(position) => (position, KlickQuelle::Maus),
+            Either::Right((finger, position)) => (position, KlickQuelle::Touch(finger)),
+        };
+        if let Some(canvas_pos) = berechne_canvas_position(
+            &bounds,
+            &Cursor::Available(position),
+            &self.pivot,
+            &self.skalieren,
+        ) {
+            messages
+                .push(Nachricht::from(ZustandAktualisierenEnum::LetzteMausPosition(canvas_pos)));
+            if let ModusDaten::Bauen {
+                gehalten: Some(_),
+                letzter_klick: Some((letzte_quelle, _zeitpunkt)),
+                ..
+            } = &self.modus
+            {
+                if *letzte_quelle == quelle {
+                    messages.push(Nachricht::from(ZustandAktualisierenEnum::GehaltenBewegen(
+                        canvas_pos,
+                    )));
+                }
+            }
+            *event_status = event::Status::Captured
+        }
+    }
+
     /// [update](iced::widget::canvas::Program::update)-Methode für [Gleise]
     pub fn update(
         &self,
@@ -241,54 +351,48 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
                 y: Skalar(bounds.height),
             }))];
         match event {
-            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
-                let Gleise { zustand: zustand2, pivot, skalieren, modus, .. } = self;
-                let (status, nachrichten) = aktion_gleis_an_position(
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => self
+                .maus_oder_touch_pressed(
+                    Either::Left(cursor),
                     bounds,
-                    &cursor,
-                    modus,
-                    zustand2,
-                    pivot,
-                    skalieren,
-                    &self.sender,
-                );
-                event_status = status;
-                messages.extend(nachrichten);
-            },
-            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
-                if let ModusDaten::Bauen { gehalten: gehalten2, .. } = &self.modus {
-                    if let Some(Gehalten { gleis_steuerung, bewegt, .. }) = gehalten2 {
-                        let gleis_id = gleis_steuerung.id();
-                        if *bewegt {
-                            if !cursor.is_over(bounds) {
-                                messages.push(Nachricht::from(
-                                    ZustandAktualisierenEnum::GleisEntfernen(gleis_id),
-                                ));
-                            }
-                        } else {
-                            // setze Streckenabschnitt, falls Maus (von ButtonPressed) nicht bewegt
-                            messages.push(Nachricht::SetzeStreckenabschnitt(gleis_id));
-                        }
-                        messages.push(Nachricht::from(
-                            ZustandAktualisierenEnum::GehaltenAktualisieren(None),
-                        ));
-                        event_status = event::Status::Captured;
-                    }
-                }
-            },
-            Event::Mouse(mouse::Event::CursorMoved { position: _ }) => {
-                if let Some(canvas_pos) =
-                    berechne_canvas_position(&bounds, &cursor, &self.pivot, &self.skalieren)
-                {
-                    messages.push(Nachricht::from(ZustandAktualisierenEnum::LetzteMausPosition(
-                        canvas_pos,
-                    )));
-                    messages.push(Nachricht::from(ZustandAktualisierenEnum::GehaltenBewegen(
-                        canvas_pos,
-                    )));
-                    event_status = event::Status::Captured
-                }
-            },
+                    &mut event_status,
+                    &mut messages,
+                ),
+            Event::Touch(touch::Event::FingerPressed { id, position }) => self
+                .maus_oder_touch_pressed(
+                    Either::Right((id, position)),
+                    bounds,
+                    &mut event_status,
+                    &mut messages,
+                ),
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => self
+                .maus_oder_touch_released(
+                    Either::Left(cursor),
+                    bounds,
+                    &mut event_status,
+                    &mut messages,
+                ),
+            Event::Touch(
+                touch::Event::FingerLifted { id, position }
+                | touch::Event::FingerLost { id, position },
+            ) => self.maus_oder_touch_released(
+                Either::Right((id, position)),
+                bounds,
+                &mut event_status,
+                &mut messages,
+            ),
+            Event::Mouse(mouse::Event::CursorMoved { position }) => self.maus_oder_touch_moved(
+                Either::Left(position),
+                bounds,
+                &mut event_status,
+                &mut messages,
+            ),
+            Event::Touch(touch::Event::FingerMoved { id, position }) => self.maus_oder_touch_moved(
+                Either::Right((id, position)),
+                bounds,
+                &mut event_status,
+                &mut messages,
+            ),
             _otherwise => {},
         };
         if event_status == event::Status::Captured {
@@ -319,9 +423,11 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
                 self.letzte_maus_position = position;
                 Ok(())
             },
-            ZustandAktualisierenEnum::LetzterKlick(zeitpunkt) => {
+            ZustandAktualisierenEnum::LetzterKlick(quelle, zeitpunkt) => {
                 if let ModusDaten::Bauen { letzter_klick, .. } = &mut self.modus {
-                    *letzter_klick = zeitpunkt;
+                    *letzter_klick = Some((quelle, zeitpunkt));
+                } else {
+                    error!("LetzterKlick-Nachricht im {:?}-Modus!", &self.modus);
                 }
                 Ok(())
             },
@@ -330,8 +436,10 @@ impl<L: Leiter, AktualisierenNachricht> Gleise<L, AktualisierenNachricht> {
                 Ok(())
             },
             ZustandAktualisierenEnum::GehaltenAktualisieren(wert) => {
-                if let ModusDaten::Bauen { gehalten: gehalten2, .. } = &mut self.modus {
-                    *gehalten2 = wert;
+                if let ModusDaten::Bauen { gehalten, .. } = &mut self.modus {
+                    *gehalten = wert;
+                } else {
+                    error!("GehaltenAktualisieren-Nachricht im {:?}-Modus!", &self.modus);
                 }
                 Ok(())
             },

--- a/src/gleis/knopf.rs
+++ b/src/gleis/knopf.rs
@@ -14,6 +14,7 @@ use iced::{
     },
     Element, Length, Point, Rectangle, Renderer,
 };
+use log::debug;
 
 use crate::{
     application::{fonts::standard_text, style::thema::Thema},
@@ -196,9 +197,11 @@ where
         }
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+                debug!("{event:?}");
                 pressed(&self.id, KlickQuelle::Maus, cursor, bounds)
             },
             Event::Touch(touch::Event::FingerPressed { id, position }) => {
+                debug!("{event:?}");
                 pressed(&self.id, KlickQuelle::Touch(id), Cursor::Available(position), bounds)
             },
             _ => (event::Status::Ignored, None),


### PR DESCRIPTION
- Gleise-Canvas hört auf Touch-Eingaben. Es können mehrere Gleise gleichzeitig bewegt werden.
- Modal-Widget unterstützt passthrough_events, die immer vom Underlay verarbeitet werden,
  selbst wenn das Overlay aktuell angezeigt wird.