### PR TITLE
add basic ci-like workflow

### DIFF
--- a/.github/workflows/build-test-lint-check.yaml
+++ b/.github/workflows/build-test-lint-check.yaml
@@ -55,11 +55,12 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
+        args: --workspace --no-fail-fast --all-targets
     - name: Check clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: -- --deny warnings
+        args: --workspace -- --deny warnings
     - name: Check outdated
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/build-test-lint-check.yaml
+++ b/.github/workflows/build-test-lint-check.yaml
@@ -1,0 +1,67 @@
+name: Build, test, lint, check
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'branch'
+        required: true
+        default: 'main'
+        type: string
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches: [ "main" ]
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == "workflow_dispatch" && inputs.branch || github.base_ref }}
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ inputs.rust-version }}
+        override: true
+        components: rustfmt, clippy
+    - name: Install cargo outdated
+      run: 
+          cargo install --locked cargo-outdated
+    - name: Setup Cache
+      uses: Swatinem/rust-cache@v2
+    - name: Check format
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+    - name: Check clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: -- --deny warnings
+    - name: Check outdated
+      uses: actions-rs/cargo@v1
+      with:
+        command: outdated
+        args: --exit-code=1 --workspace


### PR DESCRIPTION
steps:
- checkout
- install toolchain (+ cargo outdated)
- setup cache
- check format
- build
- test
- clippy
- cargo-outdated